### PR TITLE
add missing word: `de charrue`

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -54,6 +54,7 @@ const swears: string[] = [
     `de cul`,
     `de jésus marie joseph`,
     `d'esprit`,
+    `de charrue`,
 ];
 
 /**


### PR DESCRIPTION
Add `de charrue`. It's an important word, often used during heavy winter days.

Here are references showing proper use of this word:
* [Osti de charrue a marde](https://www.youtube.com/watch?v=b8eNKOIN0W4)
* [Oh l’osti de charrue a marde!](https://yayayoyo.wordpress.com/2008/02/01/oh-losti-de-charrue-a-marde/)